### PR TITLE
Feature receipts dashboard

### DIFF
--- a/src/main/java/com/istb/app/configuration/SecurityConfiguration.java
+++ b/src/main/java/com/istb/app/configuration/SecurityConfiguration.java
@@ -25,8 +25,7 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
 				"/images/**", "/css/**", "/js/**").permitAll()
 			.antMatchers("/empleados", "/empleado/**").hasRole("ADMINISTRADOR")
 			.antMatchers("/inmuebles", "/inmueble/**", "/inmueblepics", 
-				"/arrendatarios", "/arrendatario/**", 
-				"/reparacion", "/notificacion").hasAnyRole("EMPLEADO", "ADMINISTRADOR")
+				"/arrendatarios", "/arrendatario/**").hasAnyRole("EMPLEADO", "ADMINISTRADOR")
 			.antMatchers("/recibos").hasRole("ARRENDATARIO")
 			.anyRequest().authenticated();
 		

--- a/src/main/java/com/istb/app/configuration/SecurityConfiguration.java
+++ b/src/main/java/com/istb/app/configuration/SecurityConfiguration.java
@@ -27,6 +27,7 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
 			.antMatchers("/inmuebles", "/inmueble/**", "/inmueblepics", 
 				"/arrendatarios", "/arrendatario/**", 
 				"/reparacion", "/notificacion").hasAnyRole("EMPLEADO", "ADMINISTRADOR")
+			.antMatchers("/recibos").hasRole("ARRENDATARIO")
 			.anyRequest().authenticated();
 		
 		http.formLogin()

--- a/src/main/java/com/istb/app/controller/MainController.java
+++ b/src/main/java/com/istb/app/controller/MainController.java
@@ -45,13 +45,4 @@ public class MainController {
 		
 	}
 
-	@GetMapping("/recibos")
-	public String getRecibosPago(Model attributes) {
-
-		attributes.addAttribute("sectionTitle", "recibos");
-		
-		return "recibo";
-		
-	}
-		
 }

--- a/src/main/java/com/istb/app/controller/dashboard/ArrendatarioController.java
+++ b/src/main/java/com/istb/app/controller/dashboard/ArrendatarioController.java
@@ -97,7 +97,7 @@ public class ArrendatarioController {
 		return "editarArrendatario";
 
 	}
-
+	
 	@PostMapping("/arrendatario")
 	@Transactional
 	public ResponseEntity<?> nuevoArrendatario(

--- a/src/main/java/com/istb/app/controller/dashboard/ArrendatarioController.java
+++ b/src/main/java/com/istb/app/controller/dashboard/ArrendatarioController.java
@@ -12,6 +12,7 @@ import com.istb.app.entity.Arrendatario;
 import com.istb.app.repository.ArrendatarioRepositoryI;
 import com.istb.app.repository.InmuebleRepositoryI;
 import com.istb.app.services.dashboard.ArrendatarioService;
+import com.istb.app.util.AccountUtils;
 import com.istb.app.util.ControllerUtils;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -46,11 +47,27 @@ public class ArrendatarioController {
 	public String getArrendatarios(Model attributes, Authentication account) {
 
 		attributes.addAttribute("sectionTitle", "arrendatarios");
-		attributes.addAttribute("username", account.getName());
-		attributes.addAttribute("inmuebles", 
-			inmuebleRepository.findByAlquiladoOrderByIdAsc(true));
-		attributes.addAttribute("paginator", 
-			arrendatarioRepository.findAll( PageRequest.of(0, 5) ));
+		if(AccountUtils.hasRole(account, "ADMINISTRADOR")) {
+		
+			attributes.addAttribute("inmuebles", 
+				inmuebleRepository.findByAlquiladoOrderByIdAsc(true));
+			attributes.addAttribute("paginator", 
+				arrendatarioRepository.findAll( PageRequest.of(0, 5) ));
+
+		} else {
+			
+			attributes.addAttribute("inmuebles", inmuebleRepository
+				.findByAlquiladoAndEmpleados_Usuario_UsuarioOrderByIdAsc(
+					true, account.getName()
+				) 
+			);
+			attributes.addAttribute("paginator", 
+				arrendatarioRepository.findByEmpleado_Usuario_Usuario(
+					account.getName(), PageRequest.of(0, 5) 
+				)
+			);
+		
+		}
 		
 		return "arrendatario";
 		

--- a/src/main/java/com/istb/app/controller/dashboard/ArrendatarioController.java
+++ b/src/main/java/com/istb/app/controller/dashboard/ArrendatarioController.java
@@ -97,12 +97,12 @@ public class ArrendatarioController {
 		return "editarArrendatario";
 
 	}
-	
+
 	@PostMapping("/arrendatario")
 	@Transactional
 	public ResponseEntity<?> nuevoArrendatario(
 		@Valid @RequestBody Arrendatario tenant, BindingResult bindObjt) {
-
+		
 		if( bindObjt.hasErrors() ) { 
 			return ControllerUtils.getJSONBindErrors(bindObjt); }
 

--- a/src/main/java/com/istb/app/controller/dashboard/EmployeeController.java
+++ b/src/main/java/com/istb/app/controller/dashboard/EmployeeController.java
@@ -146,6 +146,8 @@ public class EmployeeController {
 			fbmanager.deleteFile(
 				empleado.getUsuario().getNombreImagenPerfil()); }
 		
+		empleado.getInmuebles().forEach( inmueble -> inmueble.setAlquilado(true) );
+
 		storedUser = empleado.getUsuario();
 		empleadoManager.deleteById(id);
 		usuarioRepository.delete(storedUser);

--- a/src/main/java/com/istb/app/controller/dashboard/InmuebleController.java
+++ b/src/main/java/com/istb/app/controller/dashboard/InmuebleController.java
@@ -67,11 +67,16 @@ public class InmuebleController {
 		attributes.addAttribute("sectionTitle", "inmuebles");
 		attributes.addAttribute("servicios", servicioRepository.findAll());
 
-		if(AccountUtils.hasRole(account, "ADMINISTRADOR")) {
-			attributes.addAttribute("empleados", empleadoRepository.findAll()); }
-		
-		attributes.addAttribute("paginator", 
-			inmuebleRepository.findAll( PageRequest.of(0, 5) ));
+		if( AccountUtils.hasRole(account, "ADMINISTRADOR") ) {
+			
+			attributes.addAttribute("empleados", empleadoRepository.findAll()); 
+			attributes.addAttribute("paginator", 
+				inmuebleRepository.findAll( PageRequest.of(0, 5) ));
+			
+		} else {
+			attributes.addAttribute("paginator", 
+				inmuebleRepository.findByEmpleados_Usuario_Usuario(
+					account.getName(), PageRequest.of(0, 5)) ); }
 		
 		return "inmueble";
 		

--- a/src/main/java/com/istb/app/controller/dashboard/InmuebleController.java
+++ b/src/main/java/com/istb/app/controller/dashboard/InmuebleController.java
@@ -43,8 +43,11 @@ import org.springframework.web.multipart.MultipartFile;
 public class InmuebleController {
 
 	@Autowired
+	private InmuebleService inmuebleManager;
+	
+	@Autowired
 	private FotosRepositoryI fotosRepository;
-
+	
 	@Autowired
 	private FirebaseStrategyService fbManager;
 	
@@ -57,9 +60,6 @@ public class InmuebleController {
 	@Autowired
 	private ServicioRepositoryI servicioRepository;
 
-	@Autowired
-	private InmuebleService inmuebleManager;
-	
 	@GetMapping("/inmuebles")
 	@Transactional
 	public String getInmueble(Model attributes, Authentication account) {

--- a/src/main/java/com/istb/app/controller/dashboard/NotificacionController.java
+++ b/src/main/java/com/istb/app/controller/dashboard/NotificacionController.java
@@ -42,9 +42,17 @@ public class NotificacionController {
 
 		if( !AccountUtils.hasRole(account, "ARRENDATARIO") ) {
 		
-			attributes.addAttribute("sectionTitle", "notificaciones para arrendatarios"); 
+			attributes.addAttribute("sectionTitle", 
+				"notificaciones para arrendatarios"); 
 			attributes.addAttribute("fechaActual", LocalDate.now());
-			attributes.addAttribute("arrendatarios", arrendatarioRepository.findAll());
+			
+			if( AccountUtils.hasRole(account, "ADMINISTRADOR") ) {
+				attributes.addAttribute("arrendatarios", 
+					arrendatarioRepository.findAll()); }
+			else { 
+				attributes.addAttribute("arrendatarios", 
+					arrendatarioRepository.findAllByEmpleado_Usuario_Usuario(
+						account.getName())); }
 			
 		} else {
 			

--- a/src/main/java/com/istb/app/controller/dashboard/ReciboPagoController.java
+++ b/src/main/java/com/istb/app/controller/dashboard/ReciboPagoController.java
@@ -1,0 +1,102 @@
+
+package com.istb.app.controller.dashboard;
+
+import java.util.Arrays;
+import java.util.List;
+
+import javax.transaction.Transactional;
+import javax.validation.Valid;
+
+import com.istb.app.entity.ReciboPago;
+import com.istb.app.models.FileUpload;
+import com.istb.app.repository.ReciboPagoRepositoryI;
+import com.istb.app.services.dashboard.ReciboPagoService;
+import com.istb.app.services.firebase.FirebaseStrategyService;
+import com.istb.app.util.ControllerUtils;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.multipart.MultipartFile;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+
+
+@Controller
+public class ReciboPagoController {
+
+	@Autowired
+	public ReciboPagoService receiptMananger;
+
+	@Autowired
+	private FirebaseStrategyService fbManager;
+	
+	@Autowired
+	private ReciboPagoRepositoryI receiptRepository;
+
+	private List<String> meses = Arrays.asList( 
+		"enero", "febrero", "marzo",
+		"abril", "mayo", "junio",
+		"julio", "agosto", "septiembre",
+		"octubre", "noviembre", "diciembre");
+
+	@GetMapping("/recibos")
+	@Transactional
+	public String getRecibosPago(Model attributes, Authentication account) {
+
+		attributes.addAttribute("sectionTitle", "recibos");
+		attributes.addAttribute("recibos", 
+			receiptRepository.findByArrendatario_Usuario_Usuario(account.getName()));
+		attributes.addAttribute("meses", meses);
+		
+		return "recibo";
+		
+	}
+	
+	@RequestMapping("/recibo")
+	@Transactional
+	public ResponseEntity<?> getReceipts(
+		@RequestParam(defaultValue = "0") int userId) {
+
+		if( userId > 0 ) {
+			return ControllerUtils.getJSONOkResponse(
+				receiptRepository.findByArrendatario_Usuario_Id(userId)); }
+		else { 
+			return ControllerUtils.getJSONOkResponse( 
+				receiptRepository.findAll(
+					PageRequest.of(0, 6, Sort.by("fechaCreacion"))) ); }
+	
+	}
+
+	@PostMapping(value="/recibo")
+	public ResponseEntity<?> addReceipt(
+		@Valid @RequestBody ReciboPago receipt, BindingResult bindObjt) {
+		
+		if(bindObjt.hasErrors()) { 
+			ControllerUtils.getJSONBindErrors(bindObjt); }
+		
+		return ControllerUtils.getJSONOkResponse(
+			receiptMananger.addReceipt(receipt).get("recibo") );
+
+	}
+
+	@PostMapping("/receiptpics")
+	@Transactional
+	public ResponseEntity<?> addRepairPic(MultipartFile[] receiptpic) 
+		throws Exception {
+			
+		List<FileUpload> files = fbManager.uploadFiles(receiptpic, "recibos");
+		
+		return ControllerUtils.getJSONOkResponse(files.get(0));
+
+	}
+	
+}

--- a/src/main/java/com/istb/app/controller/dashboard/ReparacionController.java
+++ b/src/main/java/com/istb/app/controller/dashboard/ReparacionController.java
@@ -42,9 +42,18 @@ public class ReparacionController {
 		attributes.addAttribute("sectionTitle", "reparaciones");
 		
 		if( !AccountUtils.hasRole(account, "ARRENDATARIO") ) {
-			attributes.addAttribute("reparaciones", repairRepository
-				.findByEstadoOrderByFechaCreacionDesc(EstadoReparacion.SOLICITADA)); }
-		else { 
+		
+			if( AccountUtils.hasRole(account, "ADMINISTRADOR")) {
+				attributes.addAttribute("reparaciones", repairRepository
+					.findByEstadoOrderByFechaCreacionDesc(EstadoReparacion.SOLICITADA)); }
+			else { 
+				attributes.addAttribute("reparaciones", repairRepository.
+					findByEstadoAndArrendatario_Empleado_Usuario_UsuarioOrderByFechaCreacionDesc(
+						EstadoReparacion.SOLICITADA, account.getName()
+					)
+				); }
+			
+		} else { 
 			attributes.addAttribute("reparaciones", repairRepository
 				.findByArrendatario_Usuario_UsuarioOrderByFechaCreacionDesc(
 					account.getName())); }
@@ -52,7 +61,7 @@ public class ReparacionController {
 		return "reparacion";
 		
 	}
-
+	
 	@PostMapping("/reparacion")
 	public ResponseEntity<?> addRepair(@Valid @RequestBody Reparacion repair, 
 		BindingResult bindObjt, Authentication account) {

--- a/src/main/java/com/istb/app/entity/Arrendatario.java
+++ b/src/main/java/com/istb/app/entity/Arrendatario.java
@@ -38,7 +38,7 @@ public class Arrendatario implements Serializable  {
 	@JsonIgnoreProperties({"arrendatario", "empleado"})
 	private Usuario usuario;
 	
-	@ManyToOne
+	@ManyToOne(cascade = CascadeType.ALL)
 	@JoinColumn(name = "empleado_id")
 	@JsonIgnoreProperties({"arrendatarios", "inmuebles", "reparaciones"})
 	private Empleado empleado;

--- a/src/main/java/com/istb/app/entity/DetalleFactura.java
+++ b/src/main/java/com/istb/app/entity/DetalleFactura.java
@@ -6,7 +6,6 @@ import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
-import javax.persistence.Lob;
 import javax.persistence.ManyToOne;
 import javax.persistence.Table;
 
@@ -29,7 +28,6 @@ public class DetalleFactura implements Serializable {
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private int id;
 	
-	@Lob
 	private String concepto;
 	
 	private Double monto;

--- a/src/main/java/com/istb/app/entity/Factura.java
+++ b/src/main/java/com/istb/app/entity/Factura.java
@@ -11,7 +11,6 @@ import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
-import javax.persistence.Lob;
 import javax.persistence.ManyToOne;
 import javax.persistence.OneToMany;
 import javax.persistence.Table;
@@ -39,7 +38,6 @@ public class Factura implements Serializable {
 	@Column(name = "fecha_admision")
 	private LocalDate fechaAdmision;
 	
-	@Lob
 	private String descripcion;
 	
 	@ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/istb/app/entity/Inmueble.java
+++ b/src/main/java/com/istb/app/entity/Inmueble.java
@@ -96,7 +96,7 @@ public class Inmueble implements Serializable {
 	@Override
 	public String toString() {
 
-		return String.format("[Inmueble: %]", this.titulo);
+		return String.format("[Inmueble: %s]", this.titulo);
 
 	}
 

--- a/src/main/java/com/istb/app/entity/ReciboPago.java
+++ b/src/main/java/com/istb/app/entity/ReciboPago.java
@@ -10,18 +10,15 @@ import javax.persistence.Id;
 import javax.persistence.ManyToOne;
 import javax.persistence.PrePersist;
 import javax.persistence.Table;
+import javax.validation.constraints.NotEmpty;
 
 import org.springframework.format.annotation.DateTimeFormat;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
-import lombok.AllArgsConstructor;
 import lombok.Data;
-import lombok.NoArgsConstructor;
 
 @Data
-@AllArgsConstructor
-@NoArgsConstructor
 @Entity
 @Table(name = "recibo_pagos")
 public class ReciboPago implements Serializable {
@@ -31,10 +28,12 @@ public class ReciboPago implements Serializable {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private int id;
-	
+
+	@NotEmpty(message = "Se requiere la imagen")
 	@Column(name = "url_imagen")
 	private String urlImagen;
 	
+	@NotEmpty(message = "Por favor seleccione una imagen")
 	@Column(name = "nombre_imagen")
 	private String nombreImagen;
 	
@@ -42,6 +41,7 @@ public class ReciboPago implements Serializable {
 	@DateTimeFormat(pattern = "yyyy-MM-dd HH:mm:ss")
 	private LocalDateTime fechaCreacion;
 	
+	@NotEmpty(message = "Se requiere el periodo de pago")
 	@Column(name = "periodo_pago")
 	private String periodoPago;
 	
@@ -51,6 +51,18 @@ public class ReciboPago implements Serializable {
 	
 	@PrePersist
 	public void preCreated () {
+		
 		this.fechaCreacion = LocalDateTime.now();
+		this.periodoPago = String.format("%s del %s", 
+			this.periodoPago, this.fechaCreacion.getYear());
+
 	}
+
+	@Override
+	public String toString() {
+
+		return String.format("[Recibo de pago: %s]", 
+			this.arrendatario.getUsuario().getApellidos());
+	}
+
 }

--- a/src/main/java/com/istb/app/entity/Usuario.java
+++ b/src/main/java/com/istb/app/entity/Usuario.java
@@ -80,7 +80,7 @@ public class Usuario implements Serializable {
 	private Empleado empleado;
 	
 	@OneToOne(mappedBy = "usuario")
-	@JsonIgnoreProperties({"usuario"})
+	@JsonIgnoreProperties({"usuario", "empleado", "inmuebles", "reparaciones"})
 	private Arrendatario arrendatario;
 	
 	@Column(name = "fecha_creacion", updatable = false)

--- a/src/main/java/com/istb/app/entity/Usuario.java
+++ b/src/main/java/com/istb/app/entity/Usuario.java
@@ -14,7 +14,6 @@ import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.JoinTable;
-import javax.persistence.Lob;
 import javax.persistence.ManyToMany;
 import javax.persistence.OneToOne;
 import javax.persistence.PrePersist;
@@ -92,7 +91,6 @@ public class Usuario implements Serializable {
 	@DateTimeFormat(pattern = "yyyy-MM-dd HH:mm:ss")
 	private LocalDateTime fechaActualizacion;
 	
-	@Lob
 	private String descripcion;
 
 	public Usuario(){}

--- a/src/main/java/com/istb/app/repository/ArrendatarioRepositoryI.java
+++ b/src/main/java/com/istb/app/repository/ArrendatarioRepositoryI.java
@@ -1,15 +1,23 @@
 
 package com.istb.app.repository;
 
+import java.util.List;
 import java.util.Optional;
 
 import com.istb.app.entity.Arrendatario;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ArrendatarioRepositoryI 
 	extends JpaRepository<Arrendatario, Integer> {
 
 	Optional<Arrendatario> findByUsuario_Usuario(String usuario);
-		
+	
+	List<Arrendatario> findAllByEmpleado_Usuario_Usuario(String usuario);
+	
+	Page<Arrendatario> findByEmpleado_Usuario_Usuario(
+		String usuario, Pageable paginator);
+
 }

--- a/src/main/java/com/istb/app/repository/InmuebleRepositoryI.java
+++ b/src/main/java/com/istb/app/repository/InmuebleRepositoryI.java
@@ -5,6 +5,8 @@ import java.util.List;
 
 import com.istb.app.entity.Inmueble;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface InmuebleRepositoryI 
@@ -15,5 +17,10 @@ public interface InmuebleRepositoryI
 	List<Inmueble> findByAlquilado(boolean alquilado);
 
 	List<Inmueble> findByAlquiladoOrderByIdAsc(boolean alquilado);
+	
+	Page<Inmueble> findByEmpleados_Usuario_Usuario(String usuario, Pageable paginator);
+	
+	List<Inmueble> findByAlquiladoAndEmpleados_Usuario_UsuarioOrderByIdAsc(
+		boolean alquilado, String usuario);
 	
 }

--- a/src/main/java/com/istb/app/repository/ReciboPagoRepositoryI.java
+++ b/src/main/java/com/istb/app/repository/ReciboPagoRepositoryI.java
@@ -1,0 +1,17 @@
+
+package com.istb.app.repository;
+
+import java.util.List;
+
+import com.istb.app.entity.ReciboPago;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ReciboPagoRepositoryI 
+	extends JpaRepository<ReciboPago, Integer> {
+
+	List<ReciboPago> findByArrendatario_Usuario_Id(int id);
+	List<ReciboPago> findAllByOrderByFechaCreacionDesc();
+	List<ReciboPago> findByArrendatario_Usuario_Usuario(String id);
+	
+}

--- a/src/main/java/com/istb/app/repository/ReparacionRepositoryI.java
+++ b/src/main/java/com/istb/app/repository/ReparacionRepositoryI.java
@@ -15,6 +15,9 @@ public interface ReparacionRepositoryI
 	
 	List<Reparacion> findByEstadoOrderByFechaCreacionDesc(EstadoReparacion estado);
 
+	List<Reparacion> findByEstadoAndArrendatario_Empleado_Usuario_UsuarioOrderByFechaCreacionDesc(
+		EstadoReparacion estado, String empleado);
+
 	List<Reparacion> findByArrendatario_Usuario_Usuario(String usuario);
 
 	List<Reparacion> findByArrendatario_Usuario_UsuarioOrderByFechaCreacionDesc(String usuario);

--- a/src/main/java/com/istb/app/services/dashboard/ReciboPagoService.java
+++ b/src/main/java/com/istb/app/services/dashboard/ReciboPagoService.java
@@ -1,0 +1,48 @@
+
+package com.istb.app.services.dashboard;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import javax.transaction.Transactional;
+
+import com.istb.app.entity.Arrendatario;
+import com.istb.app.entity.ReciboPago;
+import com.istb.app.repository.ArrendatarioRepositoryI;
+import com.istb.app.repository.ReciboPagoRepositoryI;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Service;
+
+@Service
+public class ReciboPagoService {
+
+	@Autowired
+	private ReciboPagoRepositoryI receiptRepository;
+
+	@Autowired
+	private ArrendatarioRepositoryI tenantRepository;
+
+	@Transactional
+	public Map<String, Object> addReceipt(ReciboPago receipt) {
+
+		Authentication account = null;
+		Optional<Arrendatario> storedTenant = null;
+		Map<String, Object> data = new HashMap<>();
+
+		account = SecurityContextHolder.getContext().getAuthentication();
+		storedTenant = tenantRepository.findByUsuario_Usuario(account.getName());
+		
+		receipt.setArrendatario( storedTenant.get() );
+
+		receiptRepository.save(receipt);
+		data.put("recibo", receipt);
+
+		return data;
+
+	}
+
+}

--- a/src/main/resources/static/js/dashboard/editarinmueble.js
+++ b/src/main/resources/static/js/dashboard/editarinmueble.js
@@ -27,12 +27,7 @@ const updateInmueble = async (event) => {
 			"fotos": [{"id": -1}]
 
 		}
-
-		// if(formValues.idEmpleado) { 
-		// 	inmuebleValues["empleados"] = [ {"id": formValues.idEmpleado} ]; }
-		// else { 
-		// 	inmuebleValues["empleados"] = [ {"id": -1} ]; }
-		
+				
 		let response = await sendJSONData("inmueble", "put", inmuebleValues);
 
 		if(response.ok) { 

--- a/src/main/resources/static/js/dashboard/recibo.js
+++ b/src/main/resources/static/js/dashboard/recibo.js
@@ -1,0 +1,118 @@
+
+import { 
+    getFormValues, sendJSONData, showNotification, uploadFiles 
+} from "../utils.js";
+
+let noReceipts = document.querySelector("#no-receipts");
+let reciboLoader = document.querySelector("#receipt-loader");
+let imgPicker = document.querySelector("#receipt-input-file");
+let formularioRecibo = document.querySelector("#receipt-form");
+let showReciboBtn = document.querySelector("#show-receipt-form");
+let agregarReciboBtn = document.querySelector("#register-receipt");
+let imgPickerBtn = document.querySelector("#receipt-input-file-btn");
+let reciboCardContainer = document.querySelector("#recibo-card-container");
+
+const agregarReciboPago = async (event) => {
+
+    event.preventDefault();
+
+    let target = event.target;
+
+    if( target.form.checkValidity() ) {
+        
+        reciboLoader.style.display = "block";
+        let subirImagen = await uploadFiles(
+            "receiptpics", "post", "receiptpic", imgPicker.files);
+        let imagenSubida = await subirImagen.json();
+        reciboLoader.style.display = "none";
+        
+        let reciboValues = {
+            "periodoPago": target.form.periodoPago.value,
+            "nombreImagen": imagenSubida.name,
+            "urlImagen": imagenSubida.url
+        }
+        
+        let request = await sendJSONData("recibo", "post", reciboValues);
+
+        if( request.ok ) {
+
+            let recibo = await request.json();
+            noReceipts.style.display = "none";
+            showNotification("Se registro el recibo de pago exitosamente", "success");
+            
+            let previousContent = reciboCardContainer.innerHTML;
+            reciboCardContainer.innerHTML = reciboDesdePlantilla(recibo)
+                .concat(previousContent);
+            [...target.form].forEach( i => i.value = "");
+        
+        } else {
+            
+            let errors = await request.json();
+            errors.forEach( error => showNotification(error.defaultMessage, "danger") );
+        
+        }
+
+    } else { 
+        showNotification("Algunos campos del formulario son incorrectos o están vacios", "danger"); }
+    
+}
+
+const reciboDesdePlantilla = (recibo) => {
+
+    return `
+    <div class="card" style="width: 20rem; margin: 12px;">
+        <img class="card-img-top" src="${recibo.urlImagen}" 
+            rel="nofollow" alt="Card image cap" style="height: 260px;">
+        <div class="card-body">
+            <p class="card-text">
+                <strong>Periodo: </strong>${recibo.periodoPago}
+            </p>
+            <a href="/recibos" class="card-link" target="_blank">Editar el recibo</a>
+            <input type="hidden" name="repairid" value="${recibo.id}">
+        </div>
+    </div>`;
+
+}
+
+const toggleAgregarRecibo = (event) => {
+
+    let target = event.target;
+    
+    if(formularioRecibo.style.display != "none") {
+    
+        formularioRecibo.style.display = "none";
+        target.innerHTML = "<i class='material-icons'>add</i> Añadir un recibo de pago";
+        toggleEmptyContainer();
+        
+    } else {
+
+        formularioRecibo.style.display = "block";
+        target.innerHTML = "<i class='material-icons'>remove</i> Ocultar panel";
+        noReceipts.style.display = "none";
+
+    }
+
+}
+
+const toggleEmptyContainer = () => {
+    
+    if( reciboCardContainer.children.length == 1 ) { 
+		noReceipts.style.display = "block"; }
+
+}
+showReciboBtn.addEventListener("click", toggleAgregarRecibo);
+agregarReciboBtn.addEventListener("click", agregarReciboPago);
+imgPickerBtn.addEventListener("click", event => imgPicker.click() );
+imgPicker.addEventListener("change", (event) => {
+
+    let target = event.target;
+
+    target.nextElementSibling.firstElementChild.placeholder = target.files[0].name;
+    
+});
+
+window.addEventListener("load", (event) => {
+
+	toggleEmptyContainer();
+
+});

--- a/src/main/resources/static/js/inmuebleInfo.js
+++ b/src/main/resources/static/js/inmuebleInfo.js
@@ -13,20 +13,17 @@ const getImueblesByZone = async (event) => {
 
 }
 
-window.addEventListener("load", (event) => {
+let index = location.href.indexOf("?")
 
-    let index = location.href.indexOf("?")
+if (index > 0) {
 
-    if(index > 0) {
-    
-        zona = location.href.substr(index + 6).replaceAll("+", " ");
-            
-        let label = [...checkBoxsLabels].filter(l => l.innerText == zona)[0];
-        label ? label.previousElementSibling.checked = true : '';
+    zona = location.href.substr(index + 6).replaceAll("+", " ");
 
-    }
+    let label = [...checkBoxsLabels].filter(l => l.innerText == zona)[0];
+    label ? label.previousElementSibling.checked = true : '';
 
-    checkBoxsLabels.forEach( label => {
-        label.previousElementSibling.addEventListener("click", getImueblesByZone)});
+}
 
+checkBoxsLabels.forEach(label => {
+    label.previousElementSibling.addEventListener("click", getImueblesByZone)
 });

--- a/src/main/resources/templates/arrendatario.html
+++ b/src/main/resources/templates/arrendatario.html
@@ -5,9 +5,8 @@
 </head>
 
 <body class="">
-
 	<div class="wrapper ">
-
+		
 		<div th:replace="maintemplate :: sidebar" class="sidebar" data-color="purple" data-background-color="white"
 			data-image="../assets/img/sidebar-1.jpg">
 		</div>
@@ -19,7 +18,6 @@
 			</nav>
 
 			<div class="content">
-
 				<button class="btn btn-danger" id="showAddTenant">
 					<i class="material-icons">add</i>
 					Añadir arrendatario
@@ -62,24 +60,16 @@
 										<input required minlength="8" type="text" class="form-control" name="contrasena"
 											id="userPassword" placeholder="Contraseña">
 									</div>
-									<div sec:authorize="hasRole('ADMINISTRADOR')" class="form-group col-md-6 label-floating has-success">
+									<div class="form-group col-md-6 label-floating has-success">
 										<select class="form-control" name="idInmueble" id="inmueble-id" required>
 											<option th:each="inmueble : ${inmuebles}"
+												th:if="${inmueble.empleados.size > 0}"
 												th:text="${inmueble.id} + ' - ' + ${inmueble.titulo} + ' / Encargad@: '
 												+ ${inmueble.empleados[0].usuario.nombres} + ' ' 
 												+ ${inmueble.empleados[0].usuario.apellidos}"
 												th:value="${inmueble.id}">Título - Encargado</option>
 										</select>
 									</div>
-									<div sec:authorize="hasRole('EMPLEADO')" class="form-group col-md-6 label-floating has-success">
-										<select class="form-control" name="idInmueble" id="inmueble-id" required>
-											<option th:each="inmueble : ${inmuebles}"
-												th:if="${inmueble.empleados[0].usuario.usuario} == ${username}"
-												th:text="${inmueble.id} + ' - ' + ${inmueble.titulo}"
-												th:value="${inmueble.id}">Título - Encargado</option>
-										</select>
-									</div>
-									
 								</div>
 								<div class="form-row flex-row-reverse">
 									<button id="registerTenant" type="submit" class="btn btn-danger"

--- a/src/main/resources/templates/recibo.html
+++ b/src/main/resources/templates/recibo.html
@@ -87,7 +87,6 @@
                             rel="nofollow" alt="Card image cap"
                             style="height: 260px;">
                         <div class="card-body">
-                            <!-- th:utext="${notificacion.fechaLimite}" -->
                             <p class="card-text" 
                                 th:utext="'<strong>Periodo: </strong>' + ${recibo.periodoPago}">
                                 <strong>Periodo: </strong>Abril 2021

--- a/src/main/resources/templates/recibo.html
+++ b/src/main/resources/templates/recibo.html
@@ -1,8 +1,5 @@
-
 <!DOCTYPE html>
-<html lang="es"
-    xmlns:th="http://www.thymeleaf.org"
-    xmlns:sec="http://www.thymeleaf.org/extras/spring-security" >
+<html lang="es" xmlns:th="http://www.thymeleaf.org" xmlns:sec="http://www.thymeleaf.org/extras/spring-security">
 
 <head th:replace="maintemplate :: head">
 </head>
@@ -22,17 +19,97 @@
             </nav>
 
             <div class="content">
-                Contenido recibos de pago
+
+                <div id="receipt-content" style="margin-bottom: 20px;">
+                    <button class="btn btn-danger" id="show-receipt-form">
+                        <i class="material-icons">add</i>
+                        Añadir un recibo de pago
+                    </button>
+                    <div class="card" id="receipt-form" style="display: none; margin: 10px; width: 63%;">
+                        <h4 class="" style="padding: 20px 0px 0px 20px;">Nuevo recibo</h4>
+                        <div class="card-body">
+                            <div>
+                                <form method="post">
+
+                                    <div class="row">
+                                        <div class="col-md-6">
+                                            <div class="form-group">
+                                                <div class="form-group">
+                                                    <select required class="form-control" name="periodoPago" id="pago">
+                                                        <option th:each="mes : ${meses}"
+                                                            th:text="${#strings.capitalize(mes)}">Mes</option>
+                                                    </select>
+                                                </div>
+                                            </div>
+                                        </div>
+                                        <div class="col-md-12">
+                                            <img id="receipt-loader" style="display: none; position: absolute; top: -110px; right: 100px;" th:src="@{/images/loader.gif}" alt="loader">
+                                            <div class="form-group form-file-upload form-file-multiple">
+                                                <input required id="receipt-input-file" type="file" multiple=""
+                                                    class="inputFileHidden">
+                                                <div class="input-group">
+                                                    <input type="text" class="form-control inputFileVisible"
+                                                        placeholder="Imagen del recibo">
+                                                    <span class="input-group-btn">
+                                                        <button id="receipt-input-file-btn" type="button"
+                                                            class="btn btn-fab btn-round btn-primary">
+                                                            <i class="material-icons">attach_file</i>
+                                                        </button>
+                                                    </span>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+
+                                    <div class="form-row flex-row-reverse">
+                                        <button id="register-receipt" type="submit" class="btn btn-danger"
+                                            style="margin-right: 0px;">Registrar recibo</button>
+                                    </div>
+                                </form>
+                            </div>
+                        </div>
+                    </div>
+
+                </div>
+
+                <div id="recibo-card-container" class="card-content" style="display: flex; flex-wrap: wrap;">
+                    
+                    <div id="no-receipts" style="display: none;">
+                        <i class="material-icons" style="font-size: 24em;">receipt</i>
+                        <span style="font-size: 1.6em; position: absolute; top: 30%">
+                            Aún no posee recibos de pago
+                        </span>
+                    </div>
+
+                    <div class="card" style="width: 20rem; margin: 12px;" th:each="recibo : ${recibos}">
+                        <img class="card-img-top"
+                            th:src="${recibo.urlImagen}" 
+                            rel="nofollow" alt="Card image cap"
+                            style="height: 260px;">
+                        <div class="card-body">
+                            <!-- th:utext="${notificacion.fechaLimite}" -->
+                            <p class="card-text" 
+                                th:utext="'<strong>Periodo: </strong>' + ${recibo.periodoPago}">
+                                <strong>Periodo: </strong>Abril 2021
+                            </p>
+                            <a th:href="@{/recibos}" class="card-link" target="_blank">Editar el recibo</a>
+                            <input type="hidden" name="repairid" th:value="${recibo.id}">
+                        </div>
+                    </div>
+
+                </div>
+
+                <footer th:replace="maintemplate :: footer" class="footer">
+                </footer>
             </div>
 
-            <footer th:replace="maintemplate :: footer" class="footer">
-            </footer>
         </div>
     </div>
     <script>
         document.querySelector(".recibos").classList.add("active")
     </script>
     <div th:replace="maintemplate :: scripts"></div>
+    <script type="module" th:src="@{/js/dashboard/recibo.js}"></script>
 </body>
 
 </html>

--- a/src/main/resources/templates/reparacion.html
+++ b/src/main/resources/templates/reparacion.html
@@ -17,7 +17,7 @@
       <nav th:replace="maintemplate :: navbar"
         class="navbar navbar-expand-lg navbar-transparent navbar-absolute fixed-top ">
       </nav>
-
+      
       <div class="content">
 
         <div sec:authorize="hasRole('ARRENDATARIO')" id="repair-content" style="margin-bottom: 20px;">


### PR DESCRIPTION

# Change log

- The tenants can add receipts
- Ignore `Arrendatario` fields on `Usuario` entity to avoid recursion on models (It generated errors when saving a tenant)
- Reduce access on `ArrendatarioController,  InmuebleController, NotificacionController and ReparacionController` (The employee user can only see the assets that he manages)

Insert | List
---|---
![imagen](https://user-images.githubusercontent.com/7263535/110533304-d5594780-80eb-11eb-9492-feb03615739b.png) | ![imagen](https://user-images.githubusercontent.com/7263535/110533206-be1a5a00-80eb-11eb-9af3-787dc1514e81.png)
